### PR TITLE
Update to Leptos 0.7 stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ readme = "README.md"
 repository = "https://github.com/sebadob/leptos-captcha"
 
 [dependencies]
-leptos = "0.7.0-beta2"
+leptos = "0.7"
 spow = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,7 @@
 #![doc = include_str!("../README.md")]
 
 use core::future::Future;
-use leptos::prelude::*;
-use leptos::spawn::spawn_local;
+use leptos::{logging::log, prelude::*, task::spawn_local};
 
 // re-export the Pow for ease of use
 pub use spow;


### PR DESCRIPTION
Currently, `leptos-captcha` can't be used on stable Leptos 0.7 versions.

* Update `Cargo.toml` Leptos dependency.
* Fix broken `use` statements for Leptos 0.7.

Tested on Leptos 0.7.7 (current stable version). Should work on any Leptos 0.7.x stable versions.